### PR TITLE
Fixed voryx/pgasync requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": "^7.3",
     "drift/http-kernel": "0.1.*",
     "mmoreram/base-bundle": "^2.1",
-    "voryx/pgasync": "^2.0"
+    "voryx/pgasync": "^2.0.2"
   },
 
   "autoload": {


### PR DESCRIPTION
`Listen` was included at version `2.0.2`